### PR TITLE
Visitor can see image for each article

### DIFF
--- a/cypress/integration/visitorCanChooseArticleByCategory.feature.js
+++ b/cypress/integration/visitorCanChooseArticleByCategory.feature.js
@@ -3,13 +3,13 @@ describe("Visitor can choose article by category", () => {
     cy.server();
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/articles",
+      url: "**/articles",
       response: "fixture:articles_list_response.json"
     });
     cy.visit("http://localhost:3001");
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/articles/**",
+      url: "**/articles/**",
       response: "fixture:article_details_response.json"
     });
   });
@@ -23,14 +23,15 @@ describe("Visitor can choose article by category", () => {
     cy.get("#article-list").within(() => {
       cy.get("#open-article-3").click();
     });
-    cy.get("#single-article").should("contain", "Thomas Got a New Car");
-    cy.get("#single-article").should(
+    cy.get("#single-article").within(() => {
+      cy.get("h1").should("contain", "Thomas Got a New Car");
+    cy.get("h4").should(
       "contain",
       "He bought it to comfort himself"
     );
-    cy.get("#single-article").should(
+    cy.get("p").should(
       "contain",
       "And now he wants a third car, that he found on Blocket."
-    );
+    )});
   });
 });

--- a/src/Display.jsx
+++ b/src/Display.jsx
@@ -1,16 +1,12 @@
 import React from "react";
 import { connect } from "react-redux";
-import { useEffect } from 'react'
 import DisplayArticles from "./components/DisplayArticles";
 import { fetchArticles } from "./state/actions/articleActions";
 import { bindActionCreators } from "redux";
 import DisplaySingleArticle from "./components/DisplaySingleArticle";
 
 const Display = props => {
-  useEffect(() => {
-    props.fetchArticles();
-  }, [])
-
+  props.fetchArticles()
   return (
     <>
       {props.showArticlesList && <DisplayArticles />}

--- a/src/components/DisplayAllArticles.jsx
+++ b/src/components/DisplayAllArticles.jsx
@@ -4,7 +4,6 @@ import { Grid, Header, Image, Button } from "semantic-ui-react";
 import ThomasCar from "../images/IMG_0745.JPG";
 import { fetchSingleArticle } from "../state/actions/articleActions";
 import { bindActionCreators } from "redux";
-import { Link } from "react-router-dom";
 
 const DisplayAllArticles = props => {
   const singleArticle = articleID => {

--- a/src/components/DisplayArticles.jsx
+++ b/src/components/DisplayArticles.jsx
@@ -19,22 +19,20 @@ const DisplayArticles = props => {
   }
   let articleDisplay = articles.map(article => {
     return (
-      <>
-        <Grid key={article.id} align="center">
-          <Grid.Column>
-            <Image src={ThomasCar} size="medium" />
-            <Header>{article.title}</Header>
-            <p>{article.lead}</p>
-            <Button
-              id={`open-article-${article.id}`}
-              onClick={() => singleArticle(article.id)}
-              key={article.id}
-            >
-              Read more
+      <Grid key={article.id} align="center">
+        <Grid.Column>
+          <Image src={article.image} size="medium" />
+          <Header>{article.title}</Header>
+          <p>{article.lead}</p>
+          <Button
+            id={`open-article-${article.id}`}
+            onClick={() => singleArticle(article.id)}
+            key={article.id}
+          >
+            Read more
             </Button>
-          </Grid.Column>
-        </Grid>
-      </>
+        </Grid.Column>
+      </Grid>
     );
   });
 

--- a/src/components/DisplayArticles.jsx
+++ b/src/components/DisplayArticles.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
 import { Grid, Header, Image, Button } from "semantic-ui-react";
-import ThomasCar from "../images/IMG_0745.JPG";
 import { fetchSingleArticle } from "../state/actions/articleActions";
 import { bindActionCreators } from "redux";
 
@@ -9,13 +8,13 @@ const DisplayArticles = props => {
   const singleArticle = articleID => {
     props.fetchSingleArticle(articleID);
   };
-  let articles
+  let articles;
   if (props.categoryName) {
     articles = props.articles.filter(article => {
-      return article.category === props.categoryName && article
-    })
+      return article.category === props.categoryName && article;
+    });
   } else {
-    articles = props.articles
+    articles = props.articles;
   }
   let articleDisplay = articles.map(article => {
     return (
@@ -30,7 +29,7 @@ const DisplayArticles = props => {
             key={article.id}
           >
             Read more
-            </Button>
+          </Button>
         </Grid.Column>
       </Grid>
     );

--- a/src/components/DisplayHeader.jsx
+++ b/src/components/DisplayHeader.jsx
@@ -4,17 +4,12 @@ import { Menu, Segment, Icon } from "semantic-ui-react";
 const DisplayHeader = () => {
   return (
     <Segment inverted>
-      <Menu inverted pointing secondary >
-        <Menu.Item
-          name="main-header"
-          id="main-header"
-          position="right"
-        >
+      <Menu inverted pointing secondary>
+        <Menu.Item name="main-header" id="main-header" position="right">
           <Icon name="sidebar" size="large"></Icon>
         </Menu.Item>
       </Menu>
     </Segment>
-
   );
 };
 

--- a/src/components/DisplayHeaderCategory.jsx
+++ b/src/components/DisplayHeaderCategory.jsx
@@ -6,70 +6,79 @@ import { CATEGORY_SELECTION } from "../state/actions/actionTypes";
 
 const HeaderCategories = props => {
   const handleItemClick = event => {
-    props.dispatch(
-      { type: CATEGORY_SELECTION, payload: { categoryName: event.target.id, activeItem: event.target.active } }
-    )
-  }
+    props.dispatch({
+      type: CATEGORY_SELECTION,
+      payload: {
+        categoryName: event.target.id,
+        activeItem: event.target.active
+      }
+    });
+  };
 
   return (
-    <Menu id='article-category' pointing secondary style={{ backgroundColor: "white" }}>
+    <Menu
+      id="article-category"
+      pointing
+      secondary
+      style={{ backgroundColor: "white" }}
+    >
       <Menu.Item
         name="All News"
         id=""
-        color='yellow'
+        color="yellow"
         as={Link}
         to={{ pathname: "/" }}
         onClick={handleItemClick}
-        active={props.activeItem === 'all'}
+        active={props.activeItem === "all"}
       />
       <Menu.Item
         name="Latest News"
         id="latest_news"
-        color='red'
+        color="red"
         as={Link}
         to={{ pathname: "/latest_news" }}
         onClick={handleItemClick}
-        active={props.activeItem === 'latest_news'}
+        active={props.activeItem === "latest_news"}
       />
       <Menu.Item
         name="Culture"
         id="culture"
-        color={'purple'}
+        color={"purple"}
         as={Link}
         to={{ pathname: "/culture" }}
         onClick={handleItemClick}
-        active={props.activeItem === 'culture'}
+        active={props.activeItem === "culture"}
       />
       <Menu.Item
         name="Tech"
         id="tech"
-        color={'blue'}
+        color={"blue"}
         as={Link}
         to={{ pathname: "/tech" }}
         onClick={handleItemClick}
-        active={props.activeItem === 'tech'}
+        active={props.activeItem === "tech"}
       />
       <Menu.Item
         name="Food"
         id="food"
-        color={'teal'}
+        color={"teal"}
         as={Link}
         to={{ pathname: "/food" }}
         onClick={handleItemClick}
-        active={props.activeItem === 'food'}
+        active={props.activeItem === "food"}
       />
       <Menu.Item
         name="Sports"
         id="sports"
-        color={'green'}
+        color={"green"}
         as={Link}
         to={{ pathname: "/sports" }}
         onClick={handleItemClick}
-        active={props.activeItem === 'sports'}
+        active={props.activeItem === "sports"}
       />
     </Menu>
   );
-}
+};
 
 const mapStateToProps = state => {
   return {

--- a/src/components/DisplayHeaderCategory.jsx
+++ b/src/components/DisplayHeaderCategory.jsx
@@ -12,7 +12,7 @@ const HeaderCategories = props => {
   }
 
   return (
-    <Menu id='article-category' pointing centered secondary style={{ backgroundColor: "white" }}>
+    <Menu id='article-category' pointing secondary style={{ backgroundColor: "white" }}>
       <Menu.Item
         name="All News"
         id=""

--- a/src/components/DisplaySingleArticle.jsx
+++ b/src/components/DisplaySingleArticle.jsx
@@ -9,8 +9,8 @@ const DisplaySingleArticle = props => {
     <>
       <Image
         size="medium"
-        centered="true"
-        src="https://react.semantic-ui.com/images/wireframe/image.png"
+        // centered
+        src={article.image} // add new chore for this 
       />
       <br />
       <Container key={article.id} align="center">

--- a/src/components/DisplaySingleArticle.jsx
+++ b/src/components/DisplaySingleArticle.jsx
@@ -7,11 +7,7 @@ const DisplaySingleArticle = props => {
   let article = props.singleArticle;
   articleDetails = (
     <>
-      <Image
-        size="medium"
-        // centered
-        src={article.image} // add new chore for this 
-      />
+      <Image size="medium" src={article.image} />
       <br />
       <Container key={article.id} align="center">
         <Header as="h1">{article.title}</Header>

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import "semantic-ui-css/semantic.min.css";
 import { BrowserRouter } from "react-router-dom";
 import axios from 'axios'
 
-axios.defaults.baseURL = "https://newsroom-team-1.herokuapp.com/";
+axios.defaults.baseURL = "https://newsroom-team-1.herokuapp.com/api";
 const store = configureStore();
 window.store = store;
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { BrowserRouter } from "react-router-dom";
 import axios from 'axios'
 
 axios.defaults.baseURL = "https://newsroom-team-1.herokuapp.com/api";
+// axios.defaults.baseURL = "http://localhost:3000/api";
 const store = configureStore();
 window.store = store;
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,12 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
-import axios from "axios";
 import { Provider } from "react-redux";
 import configureStore from "./state/store/configureStore";
 import "semantic-ui-css/semantic.min.css";
 import { BrowserRouter } from "react-router-dom";
 
-axios.defaults.baseURL = "https://newsroom-team-1.herokuapp.com/api";
+// axios.defaults.baseURL = "http:localhost:3001/api";
 const store = configureStore();
 window.store = store;
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,9 @@ import { Provider } from "react-redux";
 import configureStore from "./state/store/configureStore";
 import "semantic-ui-css/semantic.min.css";
 import { BrowserRouter } from "react-router-dom";
+import axios from 'axios'
 
-// axios.defaults.baseURL = "http:localhost:3001/api";
+axios.defaults.baseURL = "https://newsroom-team-1.herokuapp.com/";
 const store = configureStore();
 window.store = store;
 

--- a/src/state/actions/articleActions.js
+++ b/src/state/actions/articleActions.js
@@ -3,14 +3,14 @@ import { GET_ARTICLE_LIST, GET_SINGLE_ARTICLE } from "./actionTypes";
 
 const fetchArticles = () => {
   return async dispatch => {
-    let response = await axios.get("http://localhost:3000/api/articles");
+    let response = await axios.get("https://newsroom-team-1.herokuapp.com/api/articles");
     return dispatch(dispatchArticleAction(response.data));
   };
 };
 
 const fetchSingleArticle = articleID => {
   return async dispatch => {
-    let response = await axios.get(`http://localhost:3000/api/articles/${articleID}`);
+    let response = await axios.get(`https://newsroom-team-1.herokuapp.com/api/articles/${articleID}`);
     return dispatch(dispatchSingleArticleAction(response.data));
   };
 };

--- a/src/state/actions/articleActions.js
+++ b/src/state/actions/articleActions.js
@@ -3,14 +3,14 @@ import { GET_ARTICLE_LIST, GET_SINGLE_ARTICLE } from "./actionTypes";
 
 const fetchArticles = () => {
   return async dispatch => {
-    let response = await axios.get("/articles");
+    let response = await axios.get("http://localhost:3000/api/articles");
     return dispatch(dispatchArticleAction(response.data));
   };
 };
 
 const fetchSingleArticle = articleID => {
   return async dispatch => {
-    let response = await axios.get(`/articles/${articleID}`);
+    let response = await axios.get(`http://localhost:3000/api/articles/${articleID}`);
     return dispatch(dispatchSingleArticleAction(response.data));
   };
 };

--- a/src/state/actions/articleActions.js
+++ b/src/state/actions/articleActions.js
@@ -3,14 +3,14 @@ import { GET_ARTICLE_LIST, GET_SINGLE_ARTICLE } from "./actionTypes";
 
 const fetchArticles = () => {
   return async dispatch => {
-    let response = await axios.get("https://newsroom-team-1.herokuapp.com/api/articles");
+    let response = await axios.get("/articles");
     return dispatch(dispatchArticleAction(response.data));
   };
 };
 
 const fetchSingleArticle = articleID => {
   return async dispatch => {
-    let response = await axios.get(`https://newsroom-team-1.herokuapp.com/api/articles/${articleID}`);
+    let response = await axios.get(`/articles/${articleID}`);
     return dispatch(dispatchSingleArticleAction(response.data));
   };
 };


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171936768)
## User Story
```
As a visitor
In order to have a better user experience
I would like to be able to see the images that the journalist intended with each article
```
## Changes proposed in this pull request:
* Updates both the display single article and article list image src to call on article.image instead of hard coded to a default image
* Update to resolve warnings and errors when inspecting the page (completed with Thomas)
## What I have learned working on this feature:
* How to resolve some errors that come up when inspecting the page
* Calling an image from the backend to the front is simple, most of the magic is in the serialiser on the api.
## Packages/Gems added
-

## Screenshot
<img width="1494" alt="Screenshot 2020-03-26 15 48 11" src="https://user-images.githubusercontent.com/56686037/77660198-4e15d100-6f79-11ea-85a5-aac84d565d83.png">

## Lo-Fi
![Pasted Image at 2020_03_16_07_59 pm](https://user-images.githubusercontent.com/59558092/77655562-db095c00-6f72-11ea-92b3-1f49ebe93f7f.png)
